### PR TITLE
Select vxp file from command line + don't use headers from MRE SDK

### DIFF
--- a/MREmu/Bridge.cpp
+++ b/MREmu/Bridge.cpp
@@ -4,7 +4,8 @@
 #include <iostream>
 #include <unicorn/unicorn.h>
 
-#include <vmgraph.h>
+#include <Graphic.h>
+#include <System.h>
 
 const unsigned char bxlr[2] = { 0x70, 0x47 };
 const unsigned char idle_bin[2] = { 0xfe, 0xe7 };

--- a/MREmu/CMakeLists.txt
+++ b/MREmu/CMakeLists.txt
@@ -20,5 +20,6 @@ target_link_libraries(MREmu capstone)
 target_link_libraries(MREmu MREngine)
 
 target_include_directories(MREmu PUBLIC "../include")
+target_include_directories(MREmu PUBLIC "MREngine")
 
 add_subdirectory (MREngine)

--- a/MREmu/MREmu.cpp
+++ b/MREmu/MREmu.cpp
@@ -10,16 +10,25 @@
 
 #include "MREngine/Graphic.h"
 
-
-int main() {
+int main(int argc, char** argv) {
+    // Parse command arguments
+    if (argc < 2) {
+        std::cout << "MREmu by Ximik_Boda\n";
+        std::cout << "Current supported file types: vxp\n";
+        std::cout << "Usage: " << argv[0] << " [your_file]\n";
+        return 0;
+    }
+    
+    // Init subsystems
     Memory::init(128 * 1024 * 1024);
     Cpu::init();
     Bridge::init();
 
     MREngine::Graphic graphic;
 
+    // Load and start app
     App app;
-    app.load_from_file("3D_test.vxp");
+    app.load_from_file(argv[1]);
     app.preparation();
     app.start();
 

--- a/MREmu/MREngine/CMakeLists.txt
+++ b/MREmu/MREngine/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library (MREngine 
 						"Graphic.cpp" "Graphic.h"
-						"System.cpp" "System.h" )
+						"System.cpp" "System.h"  )
 
 target_link_libraries(MREngine sfml-graphics)
 target_link_libraries(MREngine imgui)

--- a/MREmu/MREngine/Graphic.cpp
+++ b/MREmu/MREngine/Graphic.cpp
@@ -1,5 +1,4 @@
 #include "Graphic.h"
-#include <vmgraph.h>
 
 static MREngine::Graphic *graphic = 0;
 

--- a/MREmu/MREngine/Graphic.h
+++ b/MREmu/MREngine/Graphic.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "System.h"
 
 namespace MREngine {
 	class Graphic {
@@ -13,3 +14,7 @@ namespace MREngine {
 		~Graphic();
 	};
 }
+
+// MRE API
+VMINT vm_graphic_get_screen_width(void);
+VMINT vm_graphic_get_screen_height(void);

--- a/MREmu/MREngine/System.cpp
+++ b/MREmu/MREngine/System.cpp
@@ -1,6 +1,5 @@
 #include "System.h"
 #include "../Memory.h"
-#include <vmsys.h>
 
 //MRE API
 

--- a/MREmu/MREngine/System.h
+++ b/MREmu/MREngine/System.h
@@ -1,6 +1,110 @@
 #pragma once
 
+// MRE common data types
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+
+/* start MRE environment normally */
+#define VM_NORMAL_START_MRE_ENV 1
+
+
+typedef unsigned char VMUINT8;
+typedef unsigned short VMUINT16;
+typedef unsigned int VMUINT;
+typedef unsigned long VMUINT32;
+
+
+typedef  unsigned long long VMUINT64;
+typedef  long long VMINT64;
+
+
+typedef char VMINT8;
+typedef short VMINT16;
+typedef int  VMINT;
+typedef long  VMINT32;
+
+typedef VMUINT8 VMUCHAR;
+typedef VMUINT16 VMUWCHAR;
+typedef VMUINT8* VMUSTR;
+typedef VMUINT16* VMUWSTR;
+
+typedef VMINT8 VMCHAR;
+typedef VMINT16 VMWCHAR;
+typedef VMINT8* VMSTR;
+typedef VMINT16* VMWSTR;
+
+typedef unsigned char VMBYTE;
+typedef unsigned short VMUSHORT;
+typedef short VMSHORT;
+
+typedef VMINT VMFILE;
+typedef VMINT VMBOOL;
+#define VM_PROF_NORMAL_MODE     0   /* normal mode */
+#define VM_PROF_MEETING_MODE    1   /* Meeting mode */
+#define VM_PROF_SILENT_MODE     2   /* Silnet mode */
+#define VM_PROF_HEADSET_MODE    3   /* Headset mode */
+#define VM_PROF_BLUETOOTH_MODE  4   /* Bluetooth profile */
+
+typedef struct vm_time_t {
+    VMINT year;
+    VMINT mon;		/* month, begin from 1	*/
+    VMINT day;		/* day,begin from  1 */
+    VMINT hour;		/* house, 24-hour	*/
+    VMINT min;		/* minute	*/
+    VMINT sec;		/* second	*/
+} vm_time_t;
+
+typedef enum
+{
+    VM_TOUCH_FEEDBACK_DOWN,
+    VM_TOUCH_FEEDBACK_DOWN_VIBRATE,
+    VM_TOUCH_FEEDBACK_DOWN_TONE,
+    VM_TOUCH_FEEDBACK_HOLD,
+    VM_TOUCH_FEEDBACK_SPECIAL,
+    VM_TOUCH_FEEDBACK_TOTAL
+} vm_touch_feedback_enum;
+
+
+typedef enum
+{
+    VM_MAINLCD_BRIGHTNESS_LEVEL0 = 0,  /* TURN OFF*/
+    VM_MAINLCD_BRIGHTNESS_LEVEL1,
+    VM_MAINLCD_BRIGHTNESS_LEVEL2,
+    VM_MAINLCD_BRIGHTNESS_LEVEL3,
+    VM_MAINLCD_BRIGHTNESS_LEVEL4,
+    VM_MAINLCD_BRIGHTNESS_LEVEL5,
+    VM_MAINLCD_BRIGHTNESS_LEVEL6,
+    VM_MAINLCD_BRIGHTNESS_LEVEL7,
+    VM_MAINLCD_BRIGHTNESS_LEVEL8,
+    VM_MAINLCD_BRIGHTNESS_LEVEL9,
+    VM_MAINLCD_BRIGHTNESS_LEVEL10,
+    VM_MAINLCD_BRIGHTNESS_LEVEL11,
+    VM_MAINLCD_BRIGHTNESS_LEVEL12,
+    VM_MAINLCD_BRIGHTNESS_LEVEL13,
+    VM_MAINLCD_BRIGHTNESS_LEVEL14,
+    VM_MAINLCD_BRIGHTNESS_LEVEL15,
+    VM_MAINLCD_BRIGHTNESS_LEVEL16,
+    VM_MAINLCD_BRIGHTNESS_LEVEL17,
+    VM_MAINLCD_BRIGHTNESS_LEVEL18,
+    VM_MAINLCD_BRIGHTNESS_LEVEL19,
+    VM_MAINLCD_BRIGHTNESS_LEVEL20,
+    VM_MAINLCD_BRIGHTNESS_20LEVEL_MAX /* DO NOT USE THIS */
+} vm_mainlcd_brightness_level_enum;
 
 namespace MREngine {
 	
 }
+
+// MRE API
+void* vm_malloc(int size);
+void vm_free(void* ptr);


### PR DESCRIPTION
Hello!

I have added basic option to select vxp file from command line (file name is get from `argv[1]`). Also, I have removed the use of MRE SDK's headers, since it's probably not good to include these proprietary headers to an open source project.