### PR TITLE
Compilation fixes and add dependencies to README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.8)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
 # Enable Hot Reload for MSVC compilers if supported.
@@ -10,6 +10,12 @@ endif()
 project ("MREmu")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+
+# Enable optimizations by default
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+endif()
 
 # Include sub-projects.
 add_subdirectory (imgui)

--- a/MREmu/AppManager.cpp
+++ b/MREmu/AppManager.cpp
@@ -2,6 +2,10 @@
 #include "Bridge.h"
 #include "ArmApp.h"
 #include "DLLApp.h"
+#include <string>
+
+extern std::string error_message;
+extern bool show_error;
 
 void AppManager::add_app_for_launch(fs::path path, bool local)
 {
@@ -31,14 +35,23 @@ void AppManager::launch_apps()
 		app = std::make_shared<DLLApp>();
 #endif // WIN32
 
-	if (!app)
+	if (!app) {
+		error_message = "VXP file format not recognized or unsupported:\n" + launch_data.path.string();
+		show_error = true;
 		return;
+	}
 
-	if (!app->load_from_file(launch_data.path, launch_data.local))
+	if (!app->load_from_file(launch_data.path, launch_data.local)) {
+		error_message = "Failed to load VXP file (file not found or access denied):\n" + launch_data.path.string();
+		show_error = true;
 		return;
+	}
 	
-	if (!app->preparation())
+	if (!app->preparation()) {
+		error_message = "VXP preparation failed (corrupt file or invalid ELF):\n" + launch_data.path.string();
+		show_error = true;
 		return;
+	}
 
 	apps.push_back(app);
 

--- a/MREmu/ArmApp.cpp
+++ b/MREmu/ArmApp.cpp
@@ -76,8 +76,10 @@ bool ArmApp::preparation()
 		{
 			std::stringstream ss;
 			ss.write((char*)file_context.data(), file_context.size());
-			if (!elf.load(ss))
-				abort();
+			if (!elf.load(ss)) {
+				printf("Failed to load ELF!\n");
+				return false;
+			}
 		}
 
 		entry_point = (elf.get_entry() + offset_mem);

--- a/MREmu/Bridge.cpp
+++ b/MREmu/Bridge.cpp
@@ -6,6 +6,8 @@
 #include "GDB.h"
 #include <string>
 #include <iostream>
+#include <thread>
+#include <chrono>
 #include <unicorn/unicorn.h>
 
 #include <vmgraph.h>
@@ -1097,11 +1099,11 @@ namespace Bridge {
 
 		if (ret == 0)
 			if (str == "vm_vsprintf")
-				ret = vsprintf;
+				ret = (void*)vsprintf;
 			else if (str == "vm_sprintf")
-				ret = sprintf;
+				ret = (void*)sprintf;
 			else if(str == "vm_sscanf")
-				ret = sscanf;
+				ret = (void*)sscanf;
 
 		printf("vm_get_sym_entry_native(%s) -> %08x\n", symbol, ret);
 
@@ -1186,7 +1188,7 @@ namespace Bridge {
 				printf("uc_emu_start returned %d (%s)\n", err, uc_strerror(err));
 				Cpu::printREG(uc);
 				while (1) {
-					Sleep(1000);
+					std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 				}
 			}
 		}

--- a/MREmu/Cpu.cpp
+++ b/MREmu/Cpu.cpp
@@ -143,15 +143,15 @@ namespace Cpu {
 	static bool hook_read_unmapped(uc_engine* uc, uc_mem_type type, uint64_t address, int size, int64_t value, void* user_data)
 	{
 		printf(">>> Try to read block at 0x%08X, block size = 0x%08X                  ---- UNMAPPED\n", (int)address, size);
-		//uc_mem_map(uc, address / 0x1000* 0x1000, 0x100000, UC_PROT_ALL);
-		return 0;
+		uc_mem_map(uc, (address / 0x1000) * 0x1000, 0x1000, UC_PROT_ALL);
+		return true;
 	}
 
 	static bool hook_write_unmapped(uc_engine* uc, uc_mem_type type, uint64_t address, int size, int64_t value, void* user_data)
 	{
 		printf(">>> Try to write block at 0x%08X, block size = 0x%08X, value = 0x%08X  ---- UNMAPPED\n", (int)address, size, (int)value);
-		//uc_mem_map(uc, address / 0x1000 * 0x1000, 0x100000, UC_PROT_ALL);
-		return 0;
+		uc_mem_map(uc, (address / 0x1000) * 0x1000, 0x1000, UC_PROT_ALL);
+		return true;
 	}
 
 	void init() {

--- a/MREmu/GDB.cpp
+++ b/MREmu/GDB.cpp
@@ -6,6 +6,9 @@
 
 #include <iostream>
 #include <string_view>
+#include <cstring>
+#include <thread>
+#include <chrono>
 
 using namespace std::string_literals;
 

--- a/MREmu/Keyboard.cpp
+++ b/MREmu/Keyboard.cpp
@@ -111,11 +111,13 @@ bool Keyboard::keyboard_event(sf::Event &event) {
 
 	const auto& el = key_to_key.find(event.key.code);
 	
-	if(el != key_to_key.end())
+	if(el != key_to_key.end()) {
 		if(event.type == sf::Event::KeyPressed)
 			kc.press_key(el->second, KeyboardControl::Keyboard);
 		else
 			kc.unpress_key(el->second);
+	}
+	return true;
 }
 
 void Keyboard::imgui_keyboard() {

--- a/MREmu/MREmu.cpp
+++ b/MREmu/MREmu.cpp
@@ -1,4 +1,4 @@
-﻿#include <iostream>
+#include <iostream>
 #include <thread>
 
 #include "imgui.h"
@@ -99,17 +99,30 @@ int main(int argc, char** argv) {
 
 	sf::Clock deltaClock;
 	sf::Event event;
-	while (win_debug.isOpen()) {
+	sf::RenderWindow win_device(sf::VideoMode(240, graphic.height + 208), "MREmu Device");
+	win_device.setFramerateLimit(60);
+
+	while (win_debug.isOpen() && win_device.isOpen()) {
 		while (win_debug.pollEvent(event)) {
-			sf::IntRect kb_rect(keyboard.x, keyboard.y, keyboard.w, keyboard.h);;
 			ImGui::SFML::ProcessEvent(event);
-			keyboard.keyboard_event(event);
 			switch (event.type) {
 			case sf::Event::Closed:
 				win_debug.close();
+				win_device.close();
 				break;
 			case sf::Event::Resized:
 				win_debug.setView(sf::View(sf::FloatRect(0.f, 0.f, (float)event.size.width, (float)event.size.height)));
+				break;
+			}
+		}
+
+		while (win_device.pollEvent(event)) {
+			sf::IntRect kb_rect(keyboard.x, keyboard.y, keyboard.w, keyboard.h);
+			keyboard.keyboard_event(event);
+			switch (event.type) {
+			case sf::Event::Closed:
+				win_device.close();
+				win_debug.close();
 				break;
 			case sf::Event::MouseButtonPressed:
 				if (event.mouseButton.button == sf::Mouse::Button::Left) {
@@ -127,6 +140,7 @@ int main(int argc, char** argv) {
 				break;
 			}
 		}
+
 		ImGui::SFML::Update(win_debug, deltaClock.restart());
 
 		graphic.update_screen();
@@ -158,18 +172,20 @@ int main(int argc, char** argv) {
 
 		{
 			sf::Sprite screen(graphic.screen_tex);
-			//screen.setScale(2, 2);
-			win_debug.draw(screen);
+			win_device.draw(screen);
 		}
 
 		Cpu::imgui_REG();
 
 		keyboard.imgui_keyboard();
-		keyboard.draw(&win_debug);
+		keyboard.draw(&win_device);
 
 		ImGui::SFML::Render(win_debug);
 		win_debug.display();
 		win_debug.clear();
+
+		win_device.display();
+		win_device.clear(sf::Color::Black);
 	}
 
 	work = false;

--- a/MREmu/MREmu.cpp
+++ b/MREmu/MREmu.cpp
@@ -25,6 +25,9 @@ sf::Clock global_clock;
 
 bool work = true;
 
+std::string error_message = "";
+bool show_error = false;
+
 AppManager* g_appManager = 0;
 
 void mre_main(AppManager* appManager_p) {
@@ -85,13 +88,14 @@ int main(int argc, char** argv) {
 
 	Keyboard keyboard;
 
-	if (app_path.size())
-		if (fs::exists(app_path) || path_is_local)
+	if (app_path.size()) {
+		if (fs::exists(app_path) || path_is_local) {
 			appManager.add_app_for_launch(app_path, path_is_local);
-		else {
-			printf("vxp file don't exists\n");
-			exit(1);
+		} else {
+			error_message = "VXP file does not exist:\n" + app_path;
+			show_error = true;
 		}
+	}
 
 	keyboard.update_pos_and_size(0, graphic.height, 240, 208);
 
@@ -100,7 +104,6 @@ int main(int argc, char** argv) {
 	sf::Clock deltaClock;
 	sf::Event event;
 	sf::RenderWindow win_device(sf::VideoMode(240, graphic.height + 208), "MREmu Device");
-	win_device.setFramerateLimit(60);
 
 	while (win_debug.isOpen() && win_device.isOpen()) {
 		while (win_debug.pollEvent(event)) {
@@ -142,6 +145,18 @@ int main(int argc, char** argv) {
 		}
 
 		ImGui::SFML::Update(win_debug, deltaClock.restart());
+
+		if (show_error) {
+			ImGui::OpenPopup("VXP Error");
+			show_error = false; // Only call OpenPopup once
+		}
+		if (ImGui::BeginPopupModal("VXP Error", NULL, ImGuiWindowFlags_AlwaysAutoResize)) {
+			ImGui::Text("%s", error_message.c_str());
+			if (ImGui::Button("OK", ImVec2(120, 0))) {
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::EndPopup();
+		}
 
 		graphic.update_screen();
 		graphic.imgui_screen();

--- a/MREmu/MREngine/Audio.cpp
+++ b/MREmu/MREngine/Audio.cpp
@@ -81,6 +81,11 @@ void vm_set_volume(VMINT volume) {
 		volume = 0;
 	if (volume > 6)
 		volume = 6;
+		
+	// Force SFML AudioDevice initialization by creating a dummy object.
+	// This prevents AL_INVALID_OPERATION if this is the first audio call on this thread.
+	static sf::SoundBuffer dummy_buffer; 
+	
 	sf::Listener::setGlobalVolume(volume * 100 / 6);
 }
 

--- a/MREmu/MREngine/Audio.h
+++ b/MREmu/MREngine/Audio.h
@@ -6,6 +6,7 @@
 #include <SFML/Audio.hpp>
 #include <adlmidi.h>
 #include <vmbitstream.h>
+#include <condition_variable>
 
 const int bitstream_buf_size = 10 * 1024;
 const int play_buf = 4410;

--- a/MREmu/MREngine/AudioBitstream.cpp
+++ b/MREmu/MREngine/AudioBitstream.cpp
@@ -1,6 +1,7 @@
 #include "Audio.h"
 #include <SFML/Audio.hpp>
 #include <vmmm.h>
+#include <cstring>
 #include <vmbitstream.h>
 
 static const int sample_rate_enum_to_int[VM_BITSTREAM_SAMPLE_FREQ_TOTAL] =

--- a/MREmu/MREngine/AudioBitstreamRec.cpp
+++ b/MREmu/MREngine/AudioBitstreamRec.cpp
@@ -1,4 +1,5 @@
 #include "Audio.h"
+#include <cstring>
 
 bool BitstreamRecord::onStart() {
 	this->setChannelCount(1);

--- a/MREmu/MREngine/CMakeLists.txt
+++ b/MREmu/MREngine/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.8)
 
 add_library (MREngine 
 						"Graphic.cpp" "Graphic.h"
@@ -25,4 +25,4 @@ target_link_libraries(MREngine imgui)
 target_link_libraries(MREngine ADLMIDI_static)
 target_link_libraries(MREngine libiconv)
 
-target_include_directories(imgui PUBLIC "$ENV{MRE_SDK}/include")
+target_include_directories(MREngine PUBLIC "$ENV{MRE_SDK}/include")

--- a/MREmu/MREngine/Graphic.cpp
+++ b/MREmu/MREngine/Graphic.cpp
@@ -116,7 +116,10 @@ void MREngine::Graphic::activate()
 }
 
 void MREngine::Graphic::update_screen() {
-	buf_to_texture(screen.data(), width, height, screen_tex);
+	if (screen_changed) {
+		buf_to_texture(screen.data(), width, height, screen_tex);
+		screen_changed = false;
+	}
 }
 
 void MREngine::Graphic::imgui_screen() {
@@ -317,6 +320,7 @@ VMINT vm_graphic_flush_layer(VMINT* layer_handles, VMINT count) {//TODO
 				break;
 			}
 
+	graphic->screen_changed = true;
 	return VM_GDI_SUCCEED;
 }
 
@@ -364,6 +368,7 @@ VM_GDI_RESULT vm_graphic_flatten_layer(VMINT* hhandle, VMINT count) {
 		if (hhandle[count - 1 - i] != gr.active_layer)
 			gr.delete_layer(hhandle[count - 1 - i]);
 
+	graphic->screen_changed = true;
 	return VM_GDI_SUCCEED;
 }
 

--- a/MREmu/MREngine/Graphic.h
+++ b/MREmu/MREngine/Graphic.h
@@ -23,6 +23,7 @@ namespace MREngine {
 	class Graphic {
 	public:
 		int width = 240, height = 320;
+		bool screen_changed = true;
 
 		sf::Texture screen_tex;
 

--- a/MREmu/MREngine/ItemsMng.h
+++ b/MREmu/MREngine/ItemsMng.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <cstdint>
+#include <cstdlib>
 
 template<class T>
 class ItemsMng {

--- a/MREmu/MREngine/Resources.h
+++ b/MREmu/MREngine/Resources.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <cstdint>
 
 namespace MREngine {
 	struct res_el {

--- a/MREmu/Memory.cpp
+++ b/MREmu/Memory.cpp
@@ -118,11 +118,13 @@ namespace Memory {
 		if (new_adr % align != 0)
 			new_adr = ((new_adr / align) + 1) * align;
 
-		if (new_adr + size < start_adr + mem_size) {
+		if (new_adr + size <= start_adr + mem_size) {
 			regions.push_back({ new_adr, size });
 			free_memory_size -= size;
 			return new_adr;
 		}
+
+		return 0;
 	}
 
 	size_t MemoryManager::realloc(size_t addr, size_t size)

--- a/MREmu/Memory.cpp
+++ b/MREmu/Memory.cpp
@@ -8,10 +8,10 @@
 #define _aligned_free(ptr) free((ptr))
 #endif // !WIN32
 
-#undef shared_memory_prt;
-#undef shared_memory_offset;
-#undef shared_memory_size;
-#undef shared_memory_in_emu_start;
+#undef shared_memory_prt
+#undef shared_memory_offset
+#undef shared_memory_size
+#undef shared_memory_in_emu_start
 
 void* shared_memory_prt = NULL;
 uint64_t shared_memory_offset = NULL;

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
 # MREmu
+
+MREmu is an emulator for the Mediatek MRE (VXP) platform.
+
+## Dependencies
+
+The project relies on several third-party libraries. Most dependencies are included directly as Git submodules (SFML, Unicorn, Capstone, libADLMIDI, libiconv-cmake), while others must be installed on your host system.
+
+**System requirements:**
+- CMake 3.8+
+- A C++20 compatible compiler (GCC, Clang, MSVC)
+- System libraries required by SFML (X11, OpenGL, FreeType, OpenAL, etc.)
+
+### Prerequisites on Linux
+
+Before building, you must install the necessary development packages for your Linux distribution.
+
+#### Fedora
+```bash
+sudo dnf install cmake gcc-c++ make openal-soft-devel freetype-devel libX11-devel libXrandr-devel libXcursor-devel libXi-devel libudev-devel mesa-libGL-devel flac-devel libvorbis-devel libogg-devel
+```
+
+#### Debian / Ubuntu
+```bash
+sudo apt update
+sudo apt install build-essential cmake libopenal-dev libfreetype-dev libx11-dev libxrandr-dev libxcursor-dev libxi-dev libudev-dev libgl1-mesa-dev libflac-dev libvorbis-dev libogg-dev
+```
+
+#### Arch Linux
+```bash
+sudo pacman -S base-devel cmake openal freetype2 libx11 libxrandr libxcursor libxi systemd libgl flac libvorbis libogg
+```
+
+## Build Instructions
+
+**1. Clone the repository and initialize submodules**
+
+If you haven't cloned the repository yet, make sure to clone recursively:
+```bash
+git clone --recursive <repository-url>
+cd MREmu
+```
+
+If you have already cloned the repository without submodules, initialize them now:
+```bash
+git submodule update --init --recursive
+```
+
+**2. Download the Mediatek SDK**
+
+The emulator engine requires the Mediatek MRE SDK headers (`vm*.h`) to compile. You must download the SDK and set the `MRE_SDK` environment variable.
+
+For Linux, you must download the official SDK installer and extract it using `innoextract`:
+```bash
+# Install innoextract (e.g. on Fedora use dnf, on Ubuntu use apt)
+sudo dnf install innoextract 
+
+mkdir -p ~/mre-sdk-temp && cd ~/mre-sdk-temp
+wget https://github.com/raspiduino/mre-sdk/releases/download/1.0.0/MRE_SDK_3.0.00.20_Normal_Eng.zip
+unzip MRE_SDK_3.0.00.20_Normal_Eng.zip
+innoextract MRE_SDK_3.0.00.20_Normal_Eng.exe
+
+# The headers will be extracted into the 'app' directory
+export MRE_SDK=~/mre-sdk-temp/app
+cd -
+```
+
+**3. Configure and build the project**
+
+Make sure the `MRE_SDK` environment variable is set in your current terminal session. Then, use CMake to configure the build environment and compile the project:
+```bash
+mkdir build
+cd build
+cmake ..
+cmake --build . -j$(nproc)
+```
+
+**4. Run the emulator**
+
+After a successful build, the executable will be placed in the `bin` directory at the project root.
+```bash
+cd ../bin
+./MREmu
+```


### PR DESCRIPTION
I have fixed some errors that came up while trying to compile this tool on my Fedora 44 install with `gcc version 16.1.1 20260515 (Red Hat 16.1.1-2) (GCC)` and have also populated the README with commands to quickly setup and install required dependencies to compile MREmu successfully.